### PR TITLE
Add more controls and work with domain account

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,16 @@
+
+default.teamcity.buildAgent_path = 'c:/BuildAgent'
+default.teamcity.servicename = "TCBuildAgent"
+default.teamcity.lsa_script_src = "lsawrapper.ps1"
+default.teamcity.lsa_script_path = File.join(Chef::Config[:file_cache_path], "lsawrapper.ps1")
+default.teamcity.buildAgent_properties_erb = 'buildAgent.properties.erb'
+ 
+# You must provide the web server here or in a Chef role
+#default.teamcity.web_server =
+
+default.teamcity.hostname = ENV['COMPUTERNAME']
+default.teamcity.workDir = '../work'
+default.teamcity.tempDir = '../temp'
+default.teamcity.systemDir = '../system'
+default.teamcity.ownPort = '9090'
+

--- a/files/default/lsawrapper.ps1
+++ b/files/default/lsawrapper.ps1
@@ -1,0 +1,244 @@
+Add-Type @'
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LsaWrapper
+{
+    using System.Runtime.InteropServices;
+    using System.Security;
+    using System.Management;
+    using System.Runtime.CompilerServices;
+    using System.ComponentModel;
+
+    using LSA_HANDLE = IntPtr;
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LSA_OBJECT_ATTRIBUTES
+    {
+        internal int Length;
+        internal IntPtr RootDirectory;
+        internal IntPtr ObjectName;
+        internal int Attributes;
+        internal IntPtr SecurityDescriptor;
+        internal IntPtr SecurityQualityOfService;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct LSA_UNICODE_STRING
+    {
+        internal ushort Length;
+        internal ushort MaximumLength;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        internal string Buffer;
+    }
+    sealed class Win32Sec
+    {
+        [DllImport("advapi32", CharSet = CharSet.Unicode, SetLastError = true),
+        SuppressUnmanagedCodeSecurityAttribute]
+        internal static extern uint LsaOpenPolicy(
+        LSA_UNICODE_STRING[] SystemName,
+        ref LSA_OBJECT_ATTRIBUTES ObjectAttributes,
+        int AccessMask,
+        out IntPtr PolicyHandle
+        );
+
+        [DllImport("advapi32", CharSet = CharSet.Unicode, SetLastError = true),
+        SuppressUnmanagedCodeSecurityAttribute]
+        internal static extern uint LsaAddAccountRights(
+        LSA_HANDLE PolicyHandle,
+        IntPtr pSID,
+        LSA_UNICODE_STRING[] UserRights,
+        int CountOfRights
+        );
+
+        [DllImport("advapi32", CharSet = CharSet.Unicode, SetLastError = true),
+        SuppressUnmanagedCodeSecurityAttribute]
+        internal static extern int LsaLookupNames2(
+        LSA_HANDLE PolicyHandle,
+        uint Flags,
+        uint Count,
+        LSA_UNICODE_STRING[] Names,
+        ref IntPtr ReferencedDomains,
+        ref IntPtr Sids
+        );
+
+        [DllImport("advapi32")]
+        internal static extern int LsaNtStatusToWinError(int NTSTATUS);
+
+        [DllImport("advapi32")]
+        internal static extern int LsaClose(IntPtr PolicyHandle);
+
+        [DllImport("advapi32")]
+        internal static extern int LsaFreeMemory(IntPtr Buffer);
+
+    }
+    /// <summary>
+    /// This class is used to grant "Log on as a service", "Log on as a batchjob", "Log on localy" etc.
+    /// to a user.
+    /// </summary>
+    public sealed class LsaWrapper : IDisposable
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        struct LSA_TRUST_INFORMATION
+        {
+            internal LSA_UNICODE_STRING Name;
+            internal IntPtr Sid;
+        }
+        [StructLayout(LayoutKind.Sequential)]
+        struct LSA_TRANSLATED_SID2
+        {
+            internal SidNameUse Use;
+            internal IntPtr Sid;
+            internal int DomainIndex;
+            uint Flags;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct LSA_REFERENCED_DOMAIN_LIST
+        {
+            internal uint Entries;
+            internal LSA_TRUST_INFORMATION Domains;
+        }
+
+        enum SidNameUse : int
+        {
+            User = 1,
+            Group = 2,
+            Domain = 3,
+            Alias = 4,
+            KnownGroup = 5,
+            DeletedAccount = 6,
+            Invalid = 7,
+            Unknown = 8,
+            Computer = 9
+        }
+
+        enum Access : int
+        {
+            POLICY_READ = 0x20006,
+            POLICY_ALL_ACCESS = 0x00F0FFF,
+            POLICY_EXECUTE = 0X20801,
+            POLICY_WRITE = 0X207F8
+        }
+        const uint STATUS_ACCESS_DENIED = 0xc0000022;
+        const uint STATUS_INSUFFICIENT_RESOURCES = 0xc000009a;
+        const uint STATUS_NO_MEMORY = 0xc0000017;
+
+        IntPtr lsaHandle;
+
+        public LsaWrapper()
+            : this(null)
+        { }
+        // // local system if systemName is null
+        public LsaWrapper(string systemName)
+        {
+            LSA_OBJECT_ATTRIBUTES lsaAttr;
+            lsaAttr.RootDirectory = IntPtr.Zero;
+            lsaAttr.ObjectName = IntPtr.Zero;
+            lsaAttr.Attributes = 0;
+            lsaAttr.SecurityDescriptor = IntPtr.Zero;
+            lsaAttr.SecurityQualityOfService = IntPtr.Zero;
+            lsaAttr.Length = Marshal.SizeOf(typeof(LSA_OBJECT_ATTRIBUTES));
+            lsaHandle = IntPtr.Zero;
+            LSA_UNICODE_STRING[] system = null;
+            if (systemName != null)
+            {
+                system = new LSA_UNICODE_STRING[1];
+                system[0] = InitLsaString(systemName);
+            }
+
+            uint ret = Win32Sec.LsaOpenPolicy(system, ref lsaAttr,
+            (int)Access.POLICY_ALL_ACCESS, out lsaHandle);
+            if (ret == 0)
+                return;
+            if (ret == STATUS_ACCESS_DENIED)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            if ((ret == STATUS_INSUFFICIENT_RESOURCES) || (ret == STATUS_NO_MEMORY))
+            {
+                throw new OutOfMemoryException();
+            }
+            throw new Win32Exception(Win32Sec.LsaNtStatusToWinError((int)ret));
+        }
+
+        public void AddPrivileges(string account, string privilege)
+        {
+            IntPtr pSid = GetSIDInformation(account);
+            LSA_UNICODE_STRING[] privileges = new LSA_UNICODE_STRING[1];
+            privileges[0] = InitLsaString(privilege);
+            uint ret = Win32Sec.LsaAddAccountRights(lsaHandle, pSid, privileges, 1);
+            if (ret == 0)
+                return;
+            if (ret == STATUS_ACCESS_DENIED)
+            {
+                throw new UnauthorizedAccessException();
+            }
+            if ((ret == STATUS_INSUFFICIENT_RESOURCES) || (ret == STATUS_NO_MEMORY))
+            {
+                throw new OutOfMemoryException();
+            }
+            throw new Win32Exception(Win32Sec.LsaNtStatusToWinError((int)ret));
+        }
+
+        public void Dispose()
+        {
+            if (lsaHandle != IntPtr.Zero)
+            {
+                Win32Sec.LsaClose(lsaHandle);
+                lsaHandle = IntPtr.Zero;
+            }
+            GC.SuppressFinalize(this);
+        }
+        ~LsaWrapper()
+        {
+            Dispose();
+        }
+        // helper functions
+
+        IntPtr GetSIDInformation(string account)
+        {
+            LSA_UNICODE_STRING[] names = new LSA_UNICODE_STRING[1];
+            LSA_TRANSLATED_SID2 lts;
+            IntPtr tsids = IntPtr.Zero;
+            IntPtr tdom = IntPtr.Zero;
+            names[0] = InitLsaString(account);
+            lts.Sid = IntPtr.Zero;
+
+            int ret = Win32Sec.LsaLookupNames2(lsaHandle, 0, 1, names, ref tdom, ref tsids);
+            if (ret != 0)
+                throw new Win32Exception(Win32Sec.LsaNtStatusToWinError(ret));
+            lts = (LSA_TRANSLATED_SID2)Marshal.PtrToStructure(tsids,
+            typeof(LSA_TRANSLATED_SID2));
+            //These are free memory that we are returning.  Since this script will only be alive for 
+            // One call I'm just not going to free the memory.  It will get freed when powershell exits
+            //Win32Sec.LsaFreeMemory(tsids);
+            //Win32Sec.LsaFreeMemory(tdom);
+            return lts.Sid;
+        }
+
+        static LSA_UNICODE_STRING InitLsaString(string s)
+        {
+            // Unicode strings max. 32KB
+            if (s.Length > 0x7ffe)
+                throw new ArgumentException("String too long");
+            LSA_UNICODE_STRING lus = new LSA_UNICODE_STRING();
+            lus.Buffer = s;
+            lus.Length = (ushort)(s.Length * sizeof(char));
+            lus.MaximumLength = (ushort)(lus.Length + sizeof(char));
+            return lus;
+        }
+    }
+    public class LsaWrapperCaller
+    {
+        public static void AddPrivileges(string account, string privilege)
+        {
+            using (LsaWrapper lsaWrapper = new LsaWrapper())
+            {
+                lsaWrapper.AddPrivileges(account, privilege);
+            }
+        }
+    }
+}
+'@
+

--- a/recipes/agent_windows_install.rb
+++ b/recipes/agent_windows_install.rb
@@ -1,36 +1,73 @@
+### check if the Slave already exists and exit if it already it exists.
+Chef::Log.info("TeamCity build agent service \"#{node[:teamcity][:servicename]}\" found. Skipping the install.") if ::Win32::Service.exists?("#{node[:teamcity][:servicename]}")
+return if ::Win32::Service.exists?("#{node[:teamcity][:servicename]}")
+
+
 install_file = "#{Chef::Config[:file_cache_path]}/TeamCityBuildAgent.zip"
 
+
+# always download the buildagent.zip so we can update the buildagent to another TeamCity server.
 remote_file install_file do
   source "http://#{node[:teamcity][:web_server]}/update/buildAgent.zip"
-  not_if { ::File.exists? install_file }
+  action :create
 end
 
-windows_zipfile '/BuildAgent' do
+windows_zipfile node[:teamcity][:buildAgent_path] do
   source install_file
   action :unzip
-  not_if { ::File.exist?('/BuildAgent') }
+  not_if { ::File.exist?(node[:teamcity][:buildAgent_path]) }
 end
 
-unless File.exist?('c:\BuildAgent\conf\buildAgent.properties')
-  template '/BuildAgent/conf/buildAgent.properties' do
-    source 'buildAgent.properties.erb'
-    variables(
-      hostname: node[:hostname],
-      web_server: node[:teamcity][:web_server]
-    )
+
+  ### run a powershell script to do the LSA so we can run the service as a specific user
+  cookbook_file node[:teamcity][:lsa_script_path] do
+    source node[:teamcity][:lsa_script_src]
   end
 
-  execute 'Install agent' do
-    command 'service.install.bat'
-    cwd '/BuildAgent/bin'
+  powershell_script "Add Services Log On Privileges" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-EOH
+    $username = "#{node[:teamcity][:agent][:username]}"
+    try {
+      . #{node[:teamcity][:lsa_script_path]}
+      [LsaWrapper.LsaWrapperCaller]::AddPrivileges($username, "SeServiceLogonRight")
+    }
+    catch [Exception] {
+      Write-Error "Unable to Assign Service Logon Right.\n"
+      Write-Error $_.Exception.Message
+      exit 1
+    }
+    exit 0
+    EOH
   end
 
-  execute 'Configure agent windows service' do
-    command "sc config TCBuildAgent obj= #{node[:teamcity][:agent][:username]} password= #{node[:teamcity][:agent][:password]} TYPE= own"
-  end
+properties_file = win_friendly_path(File.join(node[:teamcity][:buildAgent_path], "conf\\buildAgent.properties"))
 
-  execute 'Start agent' do
-    command 'service.start.bat'
-    cwd '/BuildAgent/bin'
-  end
+template properties_file do
+  source node[:teamcity][:buildAgent_properties_erb]    
+  ## we don't need a variable block here since the ERB file contains the node attributes itself. This saves us from updating this recipe if we need to add more variable controls in the ERB file.
+  not_if { ::File.exist?(properties_file) }
 end
+
+execute 'Install agent' do
+  command 'service.install.bat'
+  cwd '/BuildAgent/bin'
+end
+
+## The sc.exe requires ".\" for local accounts but for domain accounts such as "eng\yoguy" then we don't want ".\eng\yoguy".
+service_username = node[:teamcity][:agent][:username]
+if ( service_username !~ /\\/ )
+  service_username = ".\\" + service_username
+end
+
+
+execute 'Configure agent windows service' do
+  command "sc.exe config #{node[:teamcity][:servicename]} obj= \"#{service_username}\" password= \"#{node[:teamcity][:agent][:password]}\" TYPE= own"
+end
+
+execute 'Start agent' do
+  command "net start #{node[:teamcity][:servicename]}"
+  cwd '/BuildAgent/bin'
+  action :run
+end
+

--- a/templates/default/buildAgent.properties.erb
+++ b/templates/default/buildAgent.properties.erb
@@ -1,9 +1,9 @@
-serverUrl=http://<%= @web_server %>/
-name=<%= @hostname %>
-workDir=../work
-tempDir=../temp
-systemDir=../system
-ownPort=9090
+serverUrl=http://<%= node[:teamcity][:web_server] %>/
+name=<%= node[:teamcity][:hostname] %>
+workDir=<%= node[:teamcity][:workDir] %>
+tempDir=<%= node[:teamcity][:tempDir] %>
+systemDir=<%= node[:teamcity][:systemDir] %>
+ownPort=<%= node[:teamcity][:ownPort] %>
 authorizationToken=
 env.pool.buildenv=unallocated
 env.2k8

--- a/templates/default/citrix.buildAgent.properties.erb
+++ b/templates/default/citrix.buildAgent.properties.erb
@@ -1,0 +1,63 @@
+## TeamCity build agent configuration file
+
+######################################
+#   Required Agent Properties        #
+######################################
+
+## The address of the TeamCity server. The same as is used to open TeamCity web interface in the browser.
+## The address may contain "http://" or "https://" prefix. If omitted, the http protocol is used.
+## Example 1:  serverUrl=buildserver.mydomain.com
+## Example 2:  serverUrl=https://buildserver.mydomain.com:8111
+serverUrl=http://<%= node[:teamcity][:web_server] %>/
+
+## The unique name of the agent used to identify this agent on the TeamCity server
+## Use blank name to let server generate it.
+## By default, this name would be created from the build agent's host name
+name=<%= node[:teamcity][:hostname] %>
+
+## Container directory to create default checkout directories for the build configurations.
+workDir=<%= node[:teamcity][:workDir] %>
+
+## Container directory for the temporary directories.
+## Please note that the directory may be cleaned between the builds.
+tempDir=<%= node[:teamcity][:tempDir] %>
+
+## Container directory for agent system files
+systemDir=<%= node[:teamcity][:systemDir] %>
+
+
+######################################
+#   Optional Agent Properties        #
+######################################
+
+## The IP address which will be used by TeamCity server to connect to the build agent.
+## If not specified, it is detected by build agent automatically,
+## but if the machine has several network interfaces, automatic detection may fail.
+#ownAddress=<own IP address or server-accessible domain name>
+
+## Optional
+## A port that TeamCity server will use to connect to the agent.
+## Please make sure that incoming connections for this port
+## are allowed on the agent computer (e.g. not blocked by a firewall)
+ownPort=<%= node[:teamcity][:ownPort] %>
+
+## A token which is used to identify this agent on the TeamCity server.
+## It is automatically generated and saved on the first agent connection to the server.
+authorizationToken=a41fec5464744f8377681f24d9234cec
+
+
+######################################
+#   Default Build Properties         #
+######################################
+## All properties starting with "system.name" will be passed to the build script as "name"
+## All properties starting with "env.name" will be set as environment variable "name" for the build process
+## Note that value should be properly escaped. (use "\\" to represent single backslash ("\"))
+## More on file structure: http://java.sun.com/j2se/1.5.0/docs/api/java/util/Properties.html#load(java.io.InputStream)
+
+# Build Script Properties
+
+#system.exampleProperty=example Value
+
+# Environment Variables
+
+#env.exampleEnvVar=example Env Value


### PR DESCRIPTION
I added more variables in the recipe.

I added attributes into the ERB file so we don't have to update the
variable block inside the template resource in the Chef recipe as we
more variables into the buildAgent.properties file.

Add Powershell (lsawrapper.ps1) script to that lets SC.exe to add rights for a domain
user to a service. Without this powershell script execution the team city agent Windows service isn't allowed to start.
